### PR TITLE
feat: scope slash-model changes to session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3850,6 +3850,7 @@ class HermesCLI:
                         self.provider = "custom"
                         self.api_key = result.api_key
                         self.base_url = result.base_url
+                        self._session_base_url_override = result.base_url
                         self.agent = None
                         self._persist_session_runtime_settings()
                         print(f"(^_^) Model changed to: {result.model} [provider: Custom] (this session only)")
@@ -3884,6 +3885,7 @@ class HermesCLI:
                         self.provider = result.target_provider
                         self.api_key = result.api_key
                         self.base_url = result.base_url
+                        self._session_base_url_override = result.base_url or None
 
                     provider_note = f" [provider: {result.provider_label}]" if result.provider_changed else ""
                     self._persist_session_runtime_settings()

--- a/cli.py
+++ b/cli.py
@@ -1101,6 +1101,7 @@ class HermesCLI:
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
+        self._session_base_url_override: Optional[str] = None
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
@@ -1885,7 +1886,11 @@ class HermesCLI:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
-                explicit_base_url=self._explicit_base_url,
+                explicit_base_url=(
+                    self._session_base_url_override
+                    if self._session_base_url_override is not None
+                    else self._explicit_base_url
+                ),
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)
@@ -1996,6 +2001,7 @@ class HermesCLI:
                 _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
                 _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
                 return False
+            self._restore_session_runtime_settings(session_meta)
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
                 self.conversation_history = restored
@@ -2080,6 +2086,7 @@ class HermesCLI:
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
             )
+            self._persist_session_runtime_settings()
 
             if self._pending_title and self._session_db:
                 try:
@@ -2159,6 +2166,7 @@ class HermesCLI:
             )
             return False
 
+        self._restore_session_runtime_settings(session_meta)
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
             self.conversation_history = restored
@@ -2191,6 +2199,80 @@ class HermesCLI:
             pass
 
         return True
+
+    def _build_session_model_config(self) -> Dict[str, Any]:
+        """Return per-session runtime metadata we want to persist in SessionDB."""
+        return {
+            "max_iterations": self.max_turns,
+            "reasoning_config": self.reasoning_config,
+            "provider": self.requested_provider,
+            "base_url": self._session_base_url_override or self.base_url,
+        }
+
+    def _persist_session_runtime_settings(self) -> None:
+        """Persist the current session-scoped model/provider/base_url to SessionDB."""
+        if not self._session_db or not self.session_id:
+            return
+
+        session_meta = self._session_db.get_session(self.session_id)
+        model_config = self._build_session_model_config()
+        try:
+            if session_meta is None:
+                self._session_db.create_session(
+                    session_id=self.session_id,
+                    source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model=self.model,
+                    model_config=model_config,
+                    billing_provider=self.requested_provider or self.provider,
+                    billing_base_url=self._session_base_url_override or self.base_url,
+                )
+                return
+
+            self._session_db.update_session_model_state(
+                self.session_id,
+                model=self.model,
+                provider=self.requested_provider or self.provider,
+                base_url=self._session_base_url_override or self.base_url,
+            )
+        except Exception:
+            logger.debug("Failed to persist session-scoped model settings", exc_info=True)
+
+    def _restore_session_runtime_settings(self, session_meta: Optional[Dict[str, Any]]) -> None:
+        """Restore model/provider/base_url from a resumed session's metadata."""
+        if not session_meta:
+            return
+
+        restored_model = session_meta.get("model")
+        if isinstance(restored_model, str) and restored_model.strip():
+            self.model = restored_model.strip()
+
+        raw_model_config = session_meta.get("model_config")
+        model_config = None
+        if isinstance(raw_model_config, str) and raw_model_config.strip():
+            try:
+                model_config = json.loads(raw_model_config)
+            except Exception:
+                logger.debug("Failed to decode session model_config for %s", self.session_id, exc_info=True)
+
+        restored_provider = session_meta.get("billing_provider")
+        if not (isinstance(restored_provider, str) and restored_provider.strip()):
+            restored_provider = model_config.get("provider") if isinstance(model_config, dict) else None
+        if isinstance(restored_provider, str) and restored_provider.strip():
+            restored_provider = restored_provider.strip()
+            self.requested_provider = restored_provider
+            self.provider = restored_provider
+
+        restored_base_url = session_meta.get("billing_base_url")
+        if not (isinstance(restored_base_url, str) and restored_base_url.strip()):
+            restored_base_url = model_config.get("base_url") if isinstance(model_config, dict) else None
+        if isinstance(restored_base_url, str) and restored_base_url.strip():
+            self.base_url = restored_base_url.strip()
+            self._session_base_url_override = self.base_url
+            if not (isinstance(restored_provider, str) and restored_provider.strip()) and "openrouter.ai" not in self.base_url:
+                self.requested_provider = "custom"
+                self.provider = "custom"
+        else:
+            self._session_base_url_override = None
 
     def _display_resumed_history(self):
         """Render a compact recap of previous conversation messages.
@@ -2950,16 +3032,16 @@ class HermesCLI:
                         session_id=self.session_id,
                         source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=self.model,
-                        model_config={
-                            "max_iterations": self.max_turns,
-                            "reasoning_config": self.reasoning_config,
-                        },
+                        model_config=self._build_session_model_config(),
+                        billing_provider=self.requested_provider or self.provider,
+                        billing_base_url=self._session_base_url_override or self.base_url,
                     )
                 except Exception:
                     pass
 
         if not silent:
             print("(^_^)v New session started!")
+            print(f"  Current model: {self.model} [provider: {self.provider or self.requested_provider or 'auto'}]")
 
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
@@ -3000,6 +3082,7 @@ class HermesCLI:
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
+        self._restore_session_runtime_settings(session_meta)
 
         # Load conversation history
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -3013,18 +3096,8 @@ class HermesCLI:
 
         # Sync the agent if already initialised
         if self.agent:
-            self.agent.session_id = target_id
-            self.agent.reset_session_state()
-            if hasattr(self.agent, "_last_flushed_db_idx"):
-                self.agent._last_flushed_db_idx = len(self.conversation_history)
-            if hasattr(self.agent, "_todo_store"):
-                try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
-                except Exception:
-                    pass
-            if hasattr(self.agent, "_invalidate_system_prompt"):
-                self.agent._invalidate_system_prompt()
+            self.agent = None
+            self._active_agent_route_signature = None
 
         title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
         msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
@@ -3141,7 +3214,11 @@ class HermesCLI:
                 current = _resolve_provider(
                     self.requested_provider,
                     explicit_api_key=self._explicit_api_key,
-                    explicit_base_url=self._explicit_base_url,
+                    explicit_base_url=(
+                        self._session_base_url_override
+                        if self._session_base_url_override is not None
+                        else self._explicit_base_url
+                    ),
                 )
             except Exception:
                 current = "openrouter"
@@ -3774,12 +3851,11 @@ class HermesCLI:
                         self.api_key = result.api_key
                         self.base_url = result.base_url
                         self.agent = None
-                        save_config_value("model.default", result.model)
-                        save_config_value("model.provider", "custom")
-                        save_config_value("model.base_url", result.base_url)
-                        print(f"(^_^)b Model changed to: {result.model} [provider: Custom]")
+                        self._persist_session_runtime_settings()
+                        print(f"(^_^) Model changed to: {result.model} [provider: Custom] (this session only)")
                         print(f"  Endpoint: {result.base_url}")
-                        print(f"  Status: connected (model auto-detected)")
+                        print("  Status: connected (model auto-detected)")
+                        print("  Global default unchanged. Use `hermes model` to change it globally.")
                     else:
                         print(f"(>_<) {result.error_message}")
                     return True
@@ -3810,26 +3886,11 @@ class HermesCLI:
                         self.base_url = result.base_url
 
                     provider_note = f" [provider: {result.provider_label}]" if result.provider_changed else ""
-
-                    if result.persist:
-                        saved_model = save_config_value("model.default", result.new_model)
-                        if result.provider_changed:
-                            save_config_value("model.provider", result.target_provider)
-                            # Persist base_url for custom endpoints; clear
-                            # when switching away from custom.
-                            if result.base_url and "openrouter.ai" not in (result.base_url or ""):
-                                save_config_value("model.base_url", result.base_url)
-                            else:
-                                save_config_value("model.base_url", None)
-                        if saved_model:
-                            print(f"(^_^)b Model changed to: {result.new_model}{provider_note} (saved to config)")
-                        else:
-                            print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
-                    else:
-                        print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
-                        if result.warning_message:
-                            print(f"  Reason: {result.warning_message}")
-                        print("  Note: Model will revert on restart. Use a verified model to save to config.")
+                    self._persist_session_runtime_settings()
+                    print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
+                    if result.warning_message:
+                        print(f"  Note: {result.warning_message}")
+                    print("  Global default unchanged. Use `hermes model` to change it globally.")
 
                     # Show endpoint info for custom providers
                     if result.is_custom_target:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1740,6 +1740,9 @@ class GatewayRunner:
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 
+        if canonical == "model":
+            return await self._handle_model_command(event)
+
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
@@ -3053,36 +3056,36 @@ class GatewayRunner:
     async def _handle_model_command(self, event: MessageEvent) -> str:
         """Handle /model command - switch model for this session."""
         from hermes_cli.model_switch import switch_model
-        from hermes_cli.models import _PROVIDER_LABELS
-        from gateway.session import SessionStore
+        from hermes_cli.models import (
+            _PROVIDER_LABELS,
+            _PROVIDER_MODELS,
+            curated_models_for_provider,
+            list_available_providers,
+        )
         from hermes_cli.runtime_provider import resolve_runtime_provider
-        import os
-        
+
+        source = event.source or self._get_event_source(event)
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
         args = event.get_command_args().strip()
-        source = self._get_event_source(event)
-        session_key = self._session_key_from_source(source)
-        
-        # No args - show current model
+
+        current_model = session_entry.model or self._resolve_gateway_model()
+        current_provider = session_entry.provider
+        current_base_url = session_entry.base_url or ""
+        current_api_key = ""
+
+        try:
+            runtime = resolve_runtime_provider(requested=current_provider or "auto")
+            if not current_base_url:
+                current_base_url = runtime.get("base_url", "")
+            current_api_key = runtime.get("api_key", "")
+            current_provider = current_provider or runtime.get("provider")
+        except Exception:
+            pass
+
+        # No args - show current model and configured provider/model choices
         if not args:
-            session_entry = self.session_store.get_session(session_key)
-            if not session_entry:
-                return "No active session"
-            
-            # Get current session model info
-            current_model = session_entry.model or self._resolve_gateway_model()
-            current_provider = session_entry.provider
-            current_base_url = session_entry.base_url
-            
-            # Resolve current provider info
-            try:
-                runtime = resolve_runtime_provider(requested=current_provider or "auto")
-                if not current_base_url:
-                    current_base_url = runtime.get("base_url", "")
-            except Exception:
-                pass
-            
             provider_label = _PROVIDER_LABELS.get(current_provider, current_provider or "auto")
-            
             lines = [
                 f"**Current model:** `{current_model}`",
                 f"  Provider: {provider_label}",
@@ -3090,74 +3093,81 @@ class GatewayRunner:
             if current_base_url and "openrouter" not in current_base_url:
                 lines.append(f"  Base URL: {current_base_url}")
             lines.append("")
-            lines.append("Switch: `/model provider:model-name` or `/model model-name`")
-            lines.append("Examples: `/model zai:glm-5.1`, `/model claude-sonnet-4`")
+
+            providers = list_available_providers()
+            authed = [p for p in providers if p.get("authenticated")]
+            unauthed = [p for p in providers if not p.get("authenticated")]
+
+            if authed:
+                lines.append("**Configured providers & models:**")
+                for provider in authed:
+                    marker = " ← active" if provider["id"] == current_provider else ""
+                    lines.append(f"• `{provider['id']}` — {provider['label']}{marker}")
+                    curated = curated_models_for_provider(provider["id"])
+                    if curated:
+                        for model_id, _desc in curated:
+                            current_marker = " ← current" if provider["id"] == current_provider and model_id == current_model else ""
+                            lines.append(f"    - `{model_id}`{current_marker}")
+                    elif provider["id"] == "custom":
+                        endpoint = current_base_url or "configured endpoint"
+                        lines.append(f"    - endpoint: {endpoint}")
+                        if provider["id"] == current_provider:
+                            lines.append(f"    - model: `{current_model}` ← current")
+                    else:
+                        lines.append("    - use `hermes model` in CLI to browse/change globally")
+            if unauthed:
+                labels = ", ".join(p["label"] for p in unauthed)
+                lines.extend(["", f"**Not configured:** {labels}", "Run: `hermes setup`"])
+
+            lines.extend([
+                "",
+                "Switch: `/model provider:model-name` or `/model model-name`",
+                "Examples: `/model zai:glm-5.1`, `/model claude-sonnet-4`",
+                "This changes only this chat/topic session.",
+            ])
             return "\n".join(lines)
-        
+
         # Check for z-ai/glm models special case
         if args.lower().startswith("z-ai") or args.lower().startswith("zai:"):
-            # List GLM models for Z.AI provider
             if args.lower() in ("z-ai", "zai"):
-                from hermes_cli.models import _PROVIDER_MODELS
                 glm_models = _PROVIDER_MODELS.get("zai", [])
                 lines = ["**GLM Models (Z.AI)**", ""]
-                for m in glm_models:
-                    if "glm" in m.lower():
-                        lines.append(f"  • {m}")
+                for model_name in glm_models:
+                    if "glm" in model_name.lower():
+                        lines.append(f"  • {model_name}")
                 lines.append("")
                 lines.append("Usage: `/model zai:glm-5.1` or `/model z-ai/glm-5.1`")
                 return "\n".join(lines)
-        
-        # Get current session state for switch_model
-        session_entry = self.session_store.get_session(session_key)
-        current_provider = session_entry.provider if session_entry else None
-        current_base_url = session_entry.base_url if session_entry else ""
-        current_api_key = ""
-        
-        # Resolve current credentials
-        try:
-            runtime = resolve_runtime_provider(requested=current_provider or "auto")
-            if not current_base_url:
-                current_base_url = runtime.get("base_url", "")
-            current_api_key = runtime.get("api_key", "")
-        except Exception:
-            pass
-        
-        # Call switch_model
+
         result = switch_model(
             args,
             current_provider=current_provider or "auto",
             current_base_url=current_base_url,
             current_api_key=current_api_key,
         )
-        
+
         if not result.success:
             return f"Failed: {result.error_message}"
-        
-        # Update session with new model info
+
         self.session_store.update_session(
             session_key,
             model=result.new_model,
             provider=result.target_provider,
             base_url=result.base_url,
         )
-        
-        # Evict cached agent so next message uses new model
         self._evict_cached_agent(session_key)
-        
-        # Build response
-        provider_label = result.provider_label
+
         lines = [f"Switched to `{result.new_model}`"]
-        lines.append(f"  Provider: {provider_label}")
+        lines.append(f"  Provider: {result.provider_label}")
         if result.base_url and "openrouter" not in result.base_url:
             lines.append(f"  Base URL: {result.base_url}")
         if result.warning_message:
             lines.append(f"  Note: {result.warning_message}")
         lines.append("")
         lines.append("This change applies to this session only.")
-        lines.append("Use /status to see current model.")
+        lines.append("Use /status or /new to confirm the active model for this chat/topic.")
         return "\n".join(lines)
-    
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3151,6 +3151,12 @@ class GatewayRunner:
 
         self.session_store.update_session(
             session_key,
+            input_tokens=session_entry.input_tokens,
+            output_tokens=session_entry.output_tokens,
+            cache_read_tokens=session_entry.cache_read_tokens,
+            cache_write_tokens=session_entry.cache_write_tokens,
+            estimated_cost_usd=session_entry.estimated_cost_usd,
+            cost_status=session_entry.cost_status,
             model=result.new_model,
             provider=result.target_provider,
             base_url=result.base_url,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -698,6 +698,12 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    def get_session(self, session_key: str) -> Optional[SessionEntry]:
+        """Get the active session entry for a session key."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def get_or_create_session(
         self,
         source: SessionSource,
@@ -774,6 +780,9 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "model": entry.model,
+                "billing_provider": entry.provider,
+                "billing_base_url": entry.base_url,
             }
 
         # SQLite operations outside the lock
@@ -844,6 +853,13 @@ class SessionStore:
 
         if self._db and db_session_id:
             try:
+                if model is not None or provider is not None or base_url is not None:
+                    self._db.update_session_model_state(
+                        db_session_id,
+                        model=model,
+                        provider=provider,
+                        base_url=base_url,
+                    )
                 self._db.set_token_counts(
                     db_session_id,
                     input_tokens=input_tokens,
@@ -899,6 +915,9 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "model": new_entry.model,
+                "billing_provider": new_entry.provider,
+                "billing_base_url": new_entry.base_url,
             }
 
         if self._db and db_end_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -369,22 +369,34 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        billing_provider: Optional[str] = None,
+        billing_base_url: Optional[str] = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
+        stored_model_config = dict(model_config) if isinstance(model_config, dict) else None
+        if stored_model_config is not None:
+            if billing_provider and not stored_model_config.get("provider"):
+                stored_model_config["provider"] = billing_provider
+            if billing_base_url and not stored_model_config.get("base_url"):
+                stored_model_config["base_url"] = billing_base_url
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, billing_provider,
+                   billing_base_url)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
                     model,
-                    json.dumps(model_config) if model_config else None,
+                    json.dumps(stored_model_config) if stored_model_config else None,
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    billing_provider,
+                    billing_base_url,
                 ),
             )
         self._execute_write(_do)
@@ -592,6 +604,56 @@ class SessionDB:
                     session_id,
                 ),
             )
+        self._execute_write(_do)
+
+    def update_session_model_state(
+        self,
+        session_id: str,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        """Persist session-scoped model/provider/base_url metadata."""
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT model_config FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+
+            model_config: Dict[str, Any] = {}
+            if row and row["model_config"]:
+                try:
+                    loaded = json.loads(row["model_config"])
+                    if isinstance(loaded, dict):
+                        model_config = loaded
+                except (json.JSONDecodeError, TypeError):
+                    model_config = {}
+
+            if provider is not None:
+                model_config["provider"] = provider
+            if base_url is not None:
+                model_config["base_url"] = base_url
+
+            conn.execute(
+                """UPDATE sessions SET
+                   model = CASE WHEN ? IS NULL THEN model ELSE ? END,
+                   billing_provider = CASE WHEN ? IS NULL THEN billing_provider ELSE ? END,
+                   billing_base_url = CASE WHEN ? IS NULL THEN billing_base_url ELSE ? END,
+                   model_config = ?
+                   WHERE id = ?""",
+                (
+                    model,
+                    model,
+                    provider,
+                    provider,
+                    base_url,
+                    base_url,
+                    json.dumps(model_config) if model_config else None,
+                    session_id,
+                ),
+            )
+
         self._execute_write(_do)
 
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -994,8 +994,12 @@ class AIAgent:
                         "max_iterations": self.max_iterations,
                         "reasoning_config": reasoning_config,
                         "max_tokens": max_tokens,
+                        "provider": self.provider,
+                        "base_url": self.base_url,
                     },
                     user_id=None,
+                    billing_provider=self.provider,
+                    billing_base_url=self.base_url,
                 )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing
@@ -5172,6 +5176,12 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                    model_config={
+                        "provider": self.provider,
+                        "base_url": self.base_url,
+                    },
+                    billing_provider=self.provider,
+                    billing_base_url=self.base_url,
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/tests/gateway/test_model_command.py
+++ b/tests/gateway/test_model_command.py
@@ -125,3 +125,58 @@ async def test_model_command_lists_current_and_configured_models():
     assert "openai-codex" in result
     assert "Not configured" in result
     runner.session_store.get_or_create_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_model_command_preserves_existing_token_totals_when_switching():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model="glm-5.1",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        input_tokens=111,
+        output_tokens=222,
+        cache_read_tokens=333,
+        cache_write_tokens=444,
+        estimated_cost_usd=1.23,
+        cost_status="estimated",
+    )
+    runner = _make_runner(session_entry)
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=SimpleNamespace(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider_label="OpenAI Codex",
+            warning_message="",
+        ),
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "z-key",
+        },
+    ):
+        await runner._handle_model_command(_make_event("/model openai-codex:gpt-5.4"))
+
+    runner.session_store.update_session.assert_called_once_with(
+        session_entry.session_key,
+        input_tokens=111,
+        output_tokens=222,
+        cache_read_tokens=333,
+        cache_write_tokens=444,
+        estimated_cost_usd=1.23,
+        cost_status="estimated",
+        model="gpt-5.4",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )

--- a/tests/gateway/test_model_command.py
+++ b/tests/gateway/test_model_command.py
@@ -1,0 +1,127 @@
+"""Tests for gateway /model command behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock(send=AsyncMock())}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._evict_cached_agent = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_handle_message_dispatches_model_command():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._handle_model_command = AsyncMock(return_value="model-ok")
+
+    result = await runner._handle_message(_make_event("/model"))
+
+    assert result == "model-ok"
+    runner._handle_model_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_command_lists_current_and_configured_models():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model="glm-5.1",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    runner = _make_runner(session_entry)
+
+    with patch(
+        "hermes_cli.models.list_available_providers",
+        return_value=[
+            {"id": "zai", "label": "Z.AI", "authenticated": True, "aliases": []},
+            {"id": "openai-codex", "label": "OpenAI Codex", "authenticated": True, "aliases": []},
+            {"id": "openrouter", "label": "OpenRouter", "authenticated": False, "aliases": []},
+        ],
+    ), patch(
+        "hermes_cli.models.curated_models_for_provider",
+        side_effect=lambda provider: [
+            ("glm-5.1", "latest"),
+            ("glm-5", "stable"),
+        ] if provider == "zai" else [("gpt-5.4", "default")],
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "z-key",
+        },
+    ):
+        result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Current model" in result
+    assert "glm-5.1" in result
+    assert "Configured providers & models" in result
+    assert "openai-codex" in result
+    assert "Not configured" in result
+    runner.session_store.get_or_create_session.assert_called_once()

--- a/tests/test_cli_new_session.py
+++ b/tests/test_cli_new_session.py
@@ -7,6 +7,7 @@ import os
 import sys
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
+import json
 
 from hermes_state import SessionDB
 from tools.todo_tool import TodoStore
@@ -220,3 +221,75 @@ def test_new_session_resets_token_counters(tmp_path):
     assert comp.last_total_tokens == 0
     assert comp.compression_count == 0
     assert comp._context_probed is False
+
+
+def test_model_switch_stays_session_scoped_across_new_session(tmp_path):
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=ModelSwitchResult(
+            success=True,
+            new_model="glm-5.1",
+            target_provider="zai",
+            provider_changed=True,
+            api_key="z-key",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            persist=True,
+            provider_label="Z.AI",
+        ),
+    ), patch("cli.save_config_value") as mock_save:
+        cli.process_command("/model zai:glm-5.1")
+
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+    mock_save.assert_not_called()
+
+    current_row = cli._session_db.get_session(cli.session_id)
+    current_config = json.loads(current_row["model_config"])
+    assert current_row["model"] == "glm-5.1"
+    assert current_config["provider"] == "zai"
+    assert current_config["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+    cli.process_command("/new")
+
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+    new_row = cli._session_db.get_session(cli.session_id)
+    if new_row is not None:
+        new_config = json.loads(new_row["model_config"])
+        assert new_row["model"] == "glm-5.1"
+        assert new_config["provider"] == "zai"
+        assert new_config["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+
+def test_preload_resumed_session_restores_model_provider_and_base_url(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        session_id="resume_me",
+        source="cli",
+        model="glm-5.1",
+        model_config={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+        },
+    )
+    db.append_message("resume_me", role="user", content="hello")
+    db.append_message("resume_me", role="assistant", content="hi")
+
+    cli = _make_cli(resume="resume_me")
+    cli._session_db = db
+
+    assert cli._preload_resumed_session() is True
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+    assert len(cli.conversation_history) == 2

--- a/tests/test_cli_new_session.py
+++ b/tests/test_cli_new_session.py
@@ -293,3 +293,33 @@ def test_preload_resumed_session_restores_model_provider_and_base_url(tmp_path):
     assert cli.requested_provider == "zai"
     assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
     assert len(cli.conversation_history) == 2
+
+
+def test_model_switch_clears_stale_session_base_url_override(tmp_path):
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    cli = _prepare_cli_with_active_session(tmp_path)
+    cli._session_base_url_override = "http://old.local/v1"
+    cli.base_url = "http://old.local/v1"
+    cli.requested_provider = "custom"
+    cli.provider = "custom"
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai-codex",
+            provider_changed=True,
+            api_key="new-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider_label="OpenAI Codex",
+        ),
+    ):
+        cli.process_command("/model openai-codex:gpt-5.4")
+
+    assert cli._session_base_url_override == "https://chatgpt.com/backend-api/codex"
+
+    row = cli._session_db.get_session(cli.session_id)
+    config = json.loads(row["model_config"])
+    assert config["base_url"] == "https://chatgpt.com/backend-api/codex"


### PR DESCRIPTION
## Summary
- make gateway `/model` actually dispatch in Telegram and list configured providers/models
- keep slash-command model overrides session-scoped for CLI and gateway chats/topics
- persist session model/provider/base_url metadata across `/new`, compaction, and CLI resume without mutating global config

## Test Plan
- pytest -q tests/test_hermes_state.py tests/gateway/test_status_command.py tests/gateway/test_resume_command.py tests/test_cli_new_session.py tests/gateway/test_model_command.py tests/gateway/test_session_info.py tests/gateway/test_session_reset_notify.py