### PR TITLE
fix: scope gateway stop/locks to current profile, add telegram token pre-flight

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -176,6 +176,17 @@ class TelegramAdapter(BasePlatformAdapter):
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
 
+    def _release_token_lock(self) -> None:
+        if not self._token_lock_identity:
+            return
+        try:
+            from gateway.status import release_scoped_lock
+            release_scoped_lock("telegram-bot-token", self._token_lock_identity)
+        except Exception as e:
+            logger.warning("[%s] Error releasing Telegram token lock: %s", self.name, e, exc_info=True)
+        finally:
+            self._token_lock_identity = None
+
     @staticmethod
     def _parse_allowed_inbound_targets(raw_targets: Any) -> set[tuple[str, Optional[str]]]:
         """Normalize inbound allowlist config into {(chat_id, thread_id)} tuples."""
@@ -640,6 +651,26 @@ class TelegramAdapter(BasePlatformAdapter):
                 builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
+
+            get_me = getattr(self._bot, "get_me", None)
+            if callable(get_me):
+                try:
+                    await get_me()
+                except Exception as preflight_err:
+                    if _is_nonretryable_auth_error(preflight_err):
+                        message = f"Telegram getMe() token validation failed: {preflight_err}"
+                        self._set_fatal_error("telegram_invalid_token", message, retryable=False)
+                        logger.error(
+                            "[%s] %s Sleeping 300s before returning failure to avoid restart loops.",
+                            self.name,
+                            message,
+                        )
+                        self._release_token_lock()
+                        self._app = None
+                        self._bot = None
+                        await asyncio.sleep(300)
+                        return False
+                    raise
             
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
@@ -784,12 +815,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
             
         except Exception as e:
-            if self._token_lock_identity:
-                try:
-                    from gateway.status import release_scoped_lock
-                    release_scoped_lock("telegram-bot-token", self._token_lock_identity)
-                except Exception:
-                    pass
+            self._release_token_lock()
             message = f"Telegram startup failed: {e}"
             if _is_nonretryable_auth_error(e):
                 self._set_fatal_error("telegram_invalid_token", message, retryable=False)
@@ -818,12 +844,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.shutdown()
             except Exception as e:
                 logger.warning("[%s] Error during Telegram disconnect: %s", self.name, e, exc_info=True)
-        if self._token_lock_identity:
-            try:
-                from gateway.status import release_scoped_lock
-                release_scoped_lock("telegram-bot-token", self._token_lock_identity)
-            except Exception as e:
-                logger.warning("[%s] Error releasing Telegram token lock: %s", self.name, e, exc_info=True)
+        self._release_token_lock()
 
         for task in self._pending_photo_batch_tasks.values():
             if task and not task.done():

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -331,7 +331,7 @@ def release_scoped_lock(scope: str, identity: str) -> None:
 
 
 def release_all_scoped_locks() -> int:
-    """Remove all scoped lock files in the lock directory.
+    """Remove scoped lock files owned by the current process.
 
     Called during --replace to clean up stale locks left by stopped/killed
     gateway processes that did not release their locks gracefully.
@@ -339,8 +339,17 @@ def release_all_scoped_locks() -> int:
     """
     lock_dir = _get_lock_dir()
     removed = 0
+    current_pid = os.getpid()
+    current_start_time = _get_process_start_time(current_pid)
     if lock_dir.exists():
         for lock_file in lock_dir.glob("*.lock"):
+            existing = _read_json_file(lock_file)
+            if not existing:
+                continue
+            if existing.get("pid") != current_pid:
+                continue
+            if existing.get("start_time") != current_start_time:
+                continue
             try:
                 lock_file.unlink(missing_ok=True)
                 removed += 1

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -163,15 +163,89 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
     return pids
 
 
-def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None) -> int:
+def _get_process_command_line(pid: int) -> str:
+    """Best-effort command line lookup for a running PID."""
+    try:
+        if is_windows():
+            result = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine", "/FORMAT:LIST"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            for line in result.stdout.splitlines():
+                if line.startswith("CommandLine="):
+                    return line[len("CommandLine="):].strip()
+            return ""
+
+        result = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _get_process_working_directory(pid: int) -> str:
+    """Best-effort working directory lookup for a running PID."""
+    try:
+        proc_cwd = Path(f"/proc/{pid}/cwd")
+        if proc_cwd.exists():
+            return str(proc_cwd.resolve())
+    except Exception:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["lsof", "-a", "-d", "cwd", "-p", str(pid), "-Fn"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("n"):
+                return line[1:].strip()
+    except Exception:
+        pass
+
+    return ""
+
+
+def _pid_matches_hermes_home(pid: int, hermes_home: str) -> bool:
+    """Return True when the PID appears to belong to the current HERMES_HOME."""
+    if not hermes_home:
+        return False
+
+    cmdline = _get_process_command_line(pid)
+    if hermes_home in cmdline:
+        return True
+
+    cwd = _get_process_working_directory(pid)
+    return bool(cwd and hermes_home in cwd)
+
+
+def kill_gateway_processes(
+    force: bool = False,
+    exclude_pids: set | None = None,
+    *,
+    all_profiles: bool = False,
+) -> int:
     """Kill any running gateway processes. Returns count killed.
 
     Args:
         force: Use SIGKILL instead of SIGTERM.
         exclude_pids: PIDs to skip (e.g. service-managed PIDs that were just
             restarted and should not be killed).
+        all_profiles: When True, skip HERMES_HOME scoping and kill every
+            matching gateway process on the machine.
     """
     pids = find_gateway_pids(exclude_pids=exclude_pids)
+    if not all_profiles:
+        hermes_home = str(get_hermes_home().resolve())
+        pids = [pid for pid in pids if _pid_matches_hermes_home(pid, hermes_home)]
     killed = 0
     
     for pid in pids:
@@ -2593,7 +2667,7 @@ def gateway_command(args):
                     service_available = True
                 except subprocess.CalledProcessError:
                     pass
-            killed = kill_gateway_processes()
+            killed = kill_gateway_processes(all_profiles=True)
             total = killed + (1 if service_available else 0)
             if total:
                 print(f"✓ Stopped {total} gateway process(es) across all profiles")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -155,3 +155,31 @@ class TestScopedLocks:
 
         status.release_scoped_lock("telegram-bot-token", "secret")
         assert not lock_path.exists()
+
+    def test_release_all_scoped_locks_only_removes_current_process_locks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_dir = tmp_path / "locks"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+
+        current_start_time = 111
+        monkeypatch.setattr(
+            status,
+            "_get_process_start_time",
+            lambda pid: current_start_time if pid == os.getpid() else 222,
+        )
+
+        owned_lock = lock_dir / "owned.lock"
+        owned_lock.write_text(json.dumps({"pid": os.getpid(), "start_time": current_start_time}))
+
+        same_pid_stale_start = lock_dir / "stale.lock"
+        same_pid_stale_start.write_text(json.dumps({"pid": os.getpid(), "start_time": 999}))
+
+        other_lock = lock_dir / "other.lock"
+        other_lock.write_text(json.dumps({"pid": 99999, "start_time": 222}))
+
+        removed = status.release_all_scoped_locks()
+
+        assert removed == 1
+        assert not owned_lock.exists()
+        assert same_pid_stale_start.exists()
+        assert other_lock.exists()

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -235,6 +235,41 @@ async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(m
 
 
 @pytest.mark.asyncio
+async def test_connect_preflight_invalid_token_sets_nonretryable_error_and_backs_off(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    released = []
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: released.append((scope, identity)),
+    )
+
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", sleep_mock)
+
+    unauthorized = type("Unauthorized", (Exception,), {})
+    bot = SimpleNamespace(get_me=AsyncMock(side_effect=unauthorized("Invalid token")))
+    app = SimpleNamespace(bot=bot)
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr("gateway.platforms.telegram.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code == "telegram_invalid_token"
+    assert adapter.fatal_error_retryable is False
+    assert "getMe() token validation failed" in adapter.fatal_error_message
+    assert released == [("telegram-bot-token", "***")]
+    sleep_mock.assert_awaited_once_with(300)
+
+
+@pytest.mark.asyncio
 async def test_connect_clears_webhook_before_polling(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -145,13 +145,37 @@ class TestGatewayStopCleanup:
         monkeypatch.setattr(
             gateway_cli,
             "kill_gateway_processes",
-            lambda force=False: kill_calls.append(force) or 2,
+            lambda force=False, all_profiles=False: kill_calls.append((force, all_profiles)) or 2,
         )
 
         gateway_cli.gateway_command(SimpleNamespace(gateway_command="stop", **{"all": True}))
 
         assert service_calls == ["stop"]
-        assert kill_calls == [False]
+        assert kill_calls == [(False, True)]
+
+    def test_kill_gateway_processes_scopes_to_current_profile(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda exclude_pids=None: [100, 200])
+        monkeypatch.setattr(gateway_cli, "_pid_matches_hermes_home", lambda pid, hermes_home: pid == 100)
+
+        killed = []
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        count = gateway_cli.kill_gateway_processes()
+
+        assert count == 1
+        assert [pid for pid, _sig in killed] == [100]
+
+    def test_kill_gateway_processes_all_profiles_bypasses_scope_filter(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda exclude_pids=None: [100, 200])
+        monkeypatch.setattr(gateway_cli, "_pid_matches_hermes_home", lambda pid, hermes_home: pid == 100)
+
+        killed = []
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        count = gateway_cli.kill_gateway_processes(all_profiles=True)
+
+        assert count == 2
+        assert [pid for pid, _sig in killed] == [100, 200]
 
 
 class TestLaunchdServiceRecovery:


### PR DESCRIPTION
## Summary

Closes #2

### 1. Scope `kill_gateway_processes()` to current HERMES_HOME
**File:** `hermes_cli/gateway.py`

`kill_gateway_processes()` previously killed ALL gateway PIDs on the machine regardless of profile. Running `hermes gateway stop` in one profile would kill every other profile's gateway too.

Now filters by HERMES_HOME — only kills processes matching the current profile's home directory. Added `all_profiles=True` param to opt into the old behavior.

### 2. Scope `release_all_scoped_locks()` to current PID
**File:** `gateway/run.py`

Previously deleted ALL lock files in the lock directory, including those held by other running profiles. Now only releases lock files owned by the current process PID.

### 3. Pre-flight Telegram token validation
**File:** `gateway/platforms/telegram.py`

Added `getMe()` call during adapter connect. If the token is invalid/revoked, sets `fatal_error_retryable=False` with a clear error instead of entering a crash loop.

## Testing
- Tests added for HERMES_HOME-scoped PID filtering
- Tests added for scoped lock release
- Tests added for pre-flight token validation failure
- Existing tests pass
