### PR TITLE
feat: gateway plist audit tool for KeepAlive and ThrottleInterval hardening

### DIFF
--- a/hermes_cli/gateway_plist_audit.py
+++ b/hermes_cli/gateway_plist_audit.py
@@ -1,0 +1,247 @@
+"""Audit and harden installed macOS Hermes gateway launchd plists.
+
+Usage:
+    python -m hermes_cli.gateway_plist_audit --dry-run
+    python -m hermes_cli.gateway_plist_audit --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import plistlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_THROTTLE_INTERVAL = 10
+DEFAULT_PATH_FALLBACK = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+@dataclass
+class AuditResult:
+    path: Path
+    found: bool
+    changed: bool
+    applied: bool
+    notes: list[str]
+    errors: list[str]
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _split_path(path_value: str | None) -> list[str]:
+    if not path_value:
+        return []
+    return [entry for entry in path_value.split(os.pathsep) if entry]
+
+
+def _dedupe(entries: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for entry in entries:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        ordered.append(entry)
+    return ordered
+
+
+def detect_venv_bin(repo_root: Path | None = None) -> Path:
+    repo_root = repo_root or _project_root()
+    repo_venv = repo_root / "venv" / "bin"
+    repo_dot_venv = repo_root / ".venv" / "bin"
+    for candidate in (repo_venv, repo_dot_venv):
+        if candidate.exists():
+            return candidate
+
+    current_prefix = os.environ.get("VIRTUAL_ENV", "").strip()
+    if current_prefix:
+        current_prefix_path = Path(current_prefix).expanduser()
+        try:
+            current_prefix_path.relative_to(repo_root)
+            return current_prefix_path / "bin"
+        except ValueError:
+            pass
+    if sys.prefix != sys.base_prefix:
+        prefix_path = Path(sys.prefix).expanduser()
+        try:
+            prefix_path.relative_to(repo_root)
+            return prefix_path / "bin"
+        except ValueError:
+            pass
+    return repo_venv
+
+
+def required_path_entries(home_dir: Path | None = None, repo_root: Path | None = None) -> list[str]:
+    home_dir = (home_dir or Path.home()).expanduser()
+    return [
+        str(detect_venv_bin(repo_root=repo_root)),
+        str(home_dir / ".local" / "bin"),
+    ]
+
+
+def build_hardened_path(
+    existing_path: str | None,
+    *,
+    home_dir: Path | None = None,
+    repo_root: Path | None = None,
+    env_path: str | None = None,
+) -> tuple[str, list[str]]:
+    required = required_path_entries(home_dir=home_dir, repo_root=repo_root)
+    existing_entries = _split_path(existing_path)
+    baseline_entries = existing_entries or _split_path(env_path or os.environ.get("PATH")) or _split_path(DEFAULT_PATH_FALLBACK)
+    hardened_entries = _dedupe(required + baseline_entries)
+    added = [entry for entry in required if entry not in existing_entries]
+    return os.pathsep.join(hardened_entries), added
+
+
+def find_gateway_plists(launch_agents_dir: Path | None = None) -> list[Path]:
+    launch_agents_dir = (launch_agents_dir or (Path.home() / "Library" / "LaunchAgents")).expanduser()
+    return sorted(launch_agents_dir.glob("ai.hermes.gateway*.plist"))
+
+
+def audit_plist(
+    plist_path: Path,
+    *,
+    apply_changes: bool,
+    home_dir: Path | None = None,
+    repo_root: Path | None = None,
+    env_path: str | None = None,
+) -> AuditResult:
+    result = AuditResult(
+        path=plist_path,
+        found=plist_path.exists(),
+        changed=False,
+        applied=False,
+        notes=[],
+        errors=[],
+    )
+    if not plist_path.exists():
+        result.errors.append("file does not exist")
+        return result
+
+    try:
+        original_bytes = plist_path.read_bytes()
+        plist_data = plistlib.loads(original_bytes)
+    except Exception as exc:  # pragma: no cover - defensive read error path
+        result.errors.append(f"failed to read plist: {exc}")
+        return result
+
+    original_keepalive = plist_data.get("KeepAlive")
+    if original_keepalive is True:
+        result.notes.append("KeepAlive already unconditional true")
+    else:
+        plist_data["KeepAlive"] = True
+        result.changed = True
+        result.notes.append(f"KeepAlive: {original_keepalive!r} -> True")
+
+    original_throttle = plist_data.get("ThrottleInterval")
+    if original_throttle == DEFAULT_THROTTLE_INTERVAL:
+        result.notes.append(f"ThrottleInterval already {DEFAULT_THROTTLE_INTERVAL}")
+    else:
+        plist_data["ThrottleInterval"] = DEFAULT_THROTTLE_INTERVAL
+        result.changed = True
+        result.notes.append(f"ThrottleInterval: {original_throttle!r} -> {DEFAULT_THROTTLE_INTERVAL}")
+
+    env_vars = plist_data.get("EnvironmentVariables")
+    if isinstance(env_vars, dict):
+        env_dict = dict(env_vars)
+    else:
+        env_dict = {}
+        result.changed = True
+        result.notes.append("EnvironmentVariables: created missing dict")
+
+    hardened_path, added_entries = build_hardened_path(
+        env_dict.get("PATH"),
+        home_dir=home_dir,
+        repo_root=repo_root,
+        env_path=env_path,
+    )
+    original_path = env_dict.get("PATH")
+    if original_path == hardened_path:
+        result.notes.append("PATH already includes required entries")
+    else:
+        env_dict["PATH"] = hardened_path
+        plist_data["EnvironmentVariables"] = env_dict
+        result.changed = True
+        if added_entries:
+            result.notes.append(f"PATH: added {', '.join(added_entries)}")
+        else:
+            result.notes.append("PATH: normalized while preserving existing entries")
+
+    if apply_changes and result.changed:
+        try:
+            plist_path.write_bytes(plistlib.dumps(plist_data, fmt=plistlib.FMT_XML, sort_keys=False))
+            result.applied = True
+        except Exception as exc:  # pragma: no cover - defensive write error path
+            result.errors.append(f"failed to write plist: {exc}")
+    return result
+
+
+def _print_result(result: AuditResult, *, dry_run: bool) -> None:
+    status = "would update" if dry_run and result.changed else "updated" if result.applied else "ok" if not result.changed else "pending"
+    print(f"{result.path} [{status}]")
+    for note in result.notes:
+        print(f"  - {note}")
+    for error in result.errors:
+        print(f"  - ERROR: {error}")
+
+
+def run_audit(*, apply_changes: bool) -> int:
+    repo_root = _project_root()
+    launch_agents_dir = Path.home() / "Library" / "LaunchAgents"
+    plist_paths = find_gateway_plists(launch_agents_dir=launch_agents_dir)
+    dry_run = not apply_changes
+
+    mode = "apply" if apply_changes else "dry-run"
+    print(f"Gateway plist audit ({mode})")
+    print(f"Scanning: {launch_agents_dir}")
+    print(f"Required PATH entries: {', '.join(required_path_entries(repo_root=repo_root))}")
+
+    if not plist_paths:
+        print("No ai.hermes.gateway*.plist files found.")
+        return 0
+
+    print(f"Found {len(plist_paths)} plist file(s).")
+    changed_count = 0
+    error_count = 0
+
+    for plist_path in plist_paths:
+        result = audit_plist(
+            plist_path,
+            apply_changes=apply_changes,
+            repo_root=repo_root,
+        )
+        if result.changed:
+            changed_count += 1
+        if result.errors:
+            error_count += len(result.errors)
+        _print_result(result, dry_run=dry_run)
+
+    action = "would change" if dry_run else "changed"
+    print(f"Summary: scanned={len(plist_paths)} {action}={changed_count} errors={error_count}")
+    return 1 if error_count else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit and harden Hermes gateway launchd plists.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Report required changes without modifying plist files.")
+    mode.add_argument("--apply", action="store_true", help="Write plist hardening changes in place.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    apply_changes = bool(args.apply)
+    return run_audit(apply_changes=apply_changes)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-gateway-plists.sh
+++ b/scripts/audit-gateway-plists.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+source venv/bin/activate
+python -m hermes_cli.gateway_plist_audit --apply

--- a/tests/hermes_cli/test_gateway_plist_audit.py
+++ b/tests/hermes_cli/test_gateway_plist_audit.py
@@ -1,0 +1,108 @@
+import plistlib
+
+from hermes_cli import gateway_plist_audit
+
+
+def test_audit_plist_updates_hardening_fields(tmp_path):
+    home_dir = tmp_path / "home"
+    launch_agents_dir = home_dir / "Library" / "LaunchAgents"
+    launch_agents_dir.mkdir(parents=True)
+    repo_root = tmp_path / "repo"
+    (repo_root / "venv" / "bin").mkdir(parents=True)
+    plist_path = launch_agents_dir / "ai.hermes.gateway-test.plist"
+
+    original = {
+        "Label": "ai.hermes.gateway-test",
+        "KeepAlive": {"SuccessfulExit": False},
+        "EnvironmentVariables": {"PATH": "/usr/bin:/bin"},
+    }
+    plist_path.write_bytes(plistlib.dumps(original, fmt=plistlib.FMT_XML, sort_keys=False))
+
+    dry_run_result = gateway_plist_audit.audit_plist(
+        plist_path,
+        apply_changes=False,
+        home_dir=home_dir,
+        repo_root=repo_root,
+        env_path="/opt/homebrew/bin:/usr/bin:/bin",
+    )
+    assert dry_run_result.changed is True
+    assert dry_run_result.applied is False
+    unchanged = plistlib.loads(plist_path.read_bytes())
+    assert unchanged["KeepAlive"] == {"SuccessfulExit": False}
+    assert "ThrottleInterval" not in unchanged
+
+    apply_result = gateway_plist_audit.audit_plist(
+        plist_path,
+        apply_changes=True,
+        home_dir=home_dir,
+        repo_root=repo_root,
+        env_path="/opt/homebrew/bin:/usr/bin:/bin",
+    )
+    assert apply_result.changed is True
+    assert apply_result.applied is True
+
+    updated = plistlib.loads(plist_path.read_bytes())
+    assert updated["KeepAlive"] is True
+    assert updated["ThrottleInterval"] == gateway_plist_audit.DEFAULT_THROTTLE_INTERVAL
+    path_entries = updated["EnvironmentVariables"]["PATH"].split(":")
+    assert path_entries[0] == str(repo_root / "venv" / "bin")
+    assert path_entries[1] == str(home_dir / ".local" / "bin")
+    assert "/usr/bin" in path_entries
+    assert "/bin" in path_entries
+
+
+def test_audit_plist_reports_no_change_when_already_hardened(tmp_path):
+    home_dir = tmp_path / "home"
+    launch_agents_dir = home_dir / "Library" / "LaunchAgents"
+    launch_agents_dir.mkdir(parents=True)
+    repo_root = tmp_path / "repo"
+    (repo_root / "venv" / "bin").mkdir(parents=True)
+    plist_path = launch_agents_dir / "ai.hermes.gateway.plist"
+    hardened_path = ":".join(
+        [
+            str(repo_root / "venv" / "bin"),
+            str(home_dir / ".local" / "bin"),
+            "/usr/bin",
+            "/bin",
+        ]
+    )
+
+    plist_path.write_bytes(
+        plistlib.dumps(
+            {
+                "Label": "ai.hermes.gateway",
+                "KeepAlive": True,
+                "ThrottleInterval": gateway_plist_audit.DEFAULT_THROTTLE_INTERVAL,
+                "EnvironmentVariables": {"PATH": hardened_path},
+            },
+            fmt=plistlib.FMT_XML,
+            sort_keys=False,
+        )
+    )
+
+    result = gateway_plist_audit.audit_plist(
+        plist_path,
+        apply_changes=False,
+        home_dir=home_dir,
+        repo_root=repo_root,
+    )
+
+    assert result.changed is False
+    assert result.applied is False
+    reloaded = plistlib.loads(plist_path.read_bytes())
+    assert reloaded["KeepAlive"] is True
+    assert reloaded["ThrottleInterval"] == gateway_plist_audit.DEFAULT_THROTTLE_INTERVAL
+
+
+def test_find_gateway_plists_only_returns_matching_files(tmp_path):
+    launch_agents_dir = tmp_path / "LaunchAgents"
+    launch_agents_dir.mkdir()
+    expected = [
+        launch_agents_dir / "ai.hermes.gateway.plist",
+        launch_agents_dir / "ai.hermes.gateway-work.plist",
+    ]
+    for path in expected:
+        path.write_text("", encoding="utf-8")
+    (launch_agents_dir / "com.example.other.plist").write_text("", encoding="utf-8")
+
+    assert gateway_plist_audit.find_gateway_plists(launch_agents_dir) == expected


### PR DESCRIPTION
## Summary

Closes #4

### Gateway plist audit tool
**File:** `hermes_cli/gateway_plist_audit.py`, `scripts/audit-gateway-plists.sh`

A Python tool that scans all `ai.hermes.gateway*.plist` files in `~/Library/LaunchAgents/` and checks/fixes:

- **KeepAlive** — ensures unconditional `<true/>` (not `SuccessfulExit` dict that skips restart on clean exit)
- **ThrottleInterval** — ensures 10-second minimum between restart attempts (prevents crash-loop CPU burn)
- **PATH** — ensures `~/.local/bin` and hermes-agent venv/bin are included

Usage:
```bash
# Dry run (report only)
python -m hermes_cli.gateway_plist_audit --dry-run

# Apply fixes
python -m hermes_cli.gateway_plist_audit --apply

# Shell wrapper
./scripts/audit-gateway-plists.sh
```

### Why this matters
The KeepAlive misconfiguration was the single biggest cause of silent gateway deaths — a clean SIGTERM exit meant launchd would NOT restart the gateway, requiring manual intervention every time.

## Testing
- Tests for plist discovery, KeepAlive fix, ThrottleInterval fix, PATH fix
- Tests for dry-run vs apply mode
- Tests for idempotency (running twice is safe)
