### PR TITLE
[codex] Harden ACP terminal notification delivery

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Deque, Optional
 
 import acp
@@ -68,6 +71,18 @@ except Exception:
 
 # Thread pool for running AIAgent (synchronous) in parallel.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
+
+
+@dataclass(frozen=True)
+class _PromptTerminalNotification:
+    method: str
+    status: str
+    final_output: str = ""
+    error_detail: str | None = None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _extract_text(
@@ -139,7 +154,6 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
-        self._tail_tasks: set[asyncio.Task[None]] = set()
 
     @staticmethod
     def _elapsed_ms(started_at: float | None) -> int | None:
@@ -147,30 +161,35 @@ class HermesACPAgent(acp.Agent):
             return None
         return max(int((time.monotonic() - started_at) * 1000), 0)
 
-    def _track_tail_task(self, task: asyncio.Task[None]) -> None:
-        self._tail_tasks.add(task)
+    def _log_prompt_lifecycle(
+        self,
+        event: str,
+        *,
+        session_id: str,
+        turn_id: str | None,
+        level: int = logging.INFO,
+        **fields: Any,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "event": event,
+            "session_id": session_id,
+            "turn_id": turn_id,
+        }
+        payload.update(fields)
+        logger.log(level, json.dumps(payload, sort_keys=True, default=str))
 
-        def _discard(done: asyncio.Task[None]) -> None:
-            self._tail_tasks.discard(done)
-            try:
-                done.result()
-            except asyncio.CancelledError:
-                return
-            except Exception:
-                logger.exception("Unhandled ACP prompt tail task failure")
-
-        task.add_done_callback(_discard)
-
-    async def _emit_session_idle(
+    async def _emit_prompt_terminal_notification(
         self,
         session_id: str,
         *,
+        turn_id: str | None,
         conn: acp.Client | None,
-        final_output: str,
+        terminal: _PromptTerminalNotification,
+        request_started_at: str,
         started_at: float | None = None,
-    ) -> None:
+    ) -> str | None:
         if conn is None:
-            return
+            return None
 
         raw_conn = getattr(conn, "_conn", None)
         send_notification = getattr(raw_conn, "send_notification", None)
@@ -179,58 +198,119 @@ class HermesACPAgent(acp.Agent):
                 "Session %s: ACP transport does not expose raw notifications",
                 session_id,
             )
-            return
+            return None
 
-        payload: dict[str, Any] = {"sessionId": session_id}
-        if final_output:
-            payload["finalOutput"] = final_output
+        terminal_emitted_at = _utc_now_iso()
+        payload: dict[str, Any] = {
+            "sessionId": session_id,
+            "status": terminal.status,
+        }
+        if turn_id:
+            payload["turnId"] = turn_id
+        if terminal.final_output:
+            payload["finalOutput"] = terminal.final_output
+        if terminal.error_detail:
+            payload["message"] = terminal.error_detail
         try:
-            await send_notification("session.idle", payload)
+            await send_notification(terminal.method, payload)
         except Exception:
+            self._log_prompt_lifecycle(
+                "hermes.acp.prompt.terminal_emit_failed",
+                session_id=session_id,
+                turn_id=turn_id,
+                level=logging.WARNING,
+                terminal_method=terminal.method,
+                terminal_status=terminal.status,
+                request_started_at=request_started_at,
+                terminal_emitted_at=terminal_emitted_at,
+                elapsed_ms=self._elapsed_ms(started_at),
+                error_detail=terminal.error_detail,
+            )
             logger.warning(
-                "Session %s: terminal lifecycle signal failed (method=session.idle, elapsed_ms=%s)",
+                "Session %s: terminal lifecycle signal failed",
                 session_id,
-                self._elapsed_ms(started_at),
                 exc_info=True,
             )
-            return
-        logger.info(
-            "Session %s: terminal lifecycle signal sent (method=session.idle, elapsed_ms=%s)",
-            session_id,
-            self._elapsed_ms(started_at),
+            return None
+        self._log_prompt_lifecycle(
+            "hermes.acp.prompt.terminal_emitted",
+            session_id=session_id,
+            turn_id=turn_id,
+            terminal_method=terminal.method,
+            terminal_status=terminal.status,
+            request_started_at=request_started_at,
+            terminal_emitted_at=terminal_emitted_at,
+            elapsed_ms=self._elapsed_ms(started_at),
+            final_output_chars=len(terminal.final_output),
+            error_detail=terminal.error_detail,
         )
+        return terminal_emitted_at
 
     async def _run_prompt_tail_work(self, session_id: str) -> None:
         await asyncio.to_thread(self.session_manager.save_session, session_id)
+
+    async def _await_prompt_response_release(
+        self,
+        session_id: str,
+        *,
+        turn_id: str | None,
+        stop_reason: str,
+        request_started_at: str,
+        terminal_emitted_at: str | None,
+    ) -> None:
+        return None
 
     async def _run_prompt_tail_work_logged(
         self,
         session_id: str,
         *,
+        turn_id: str | None,
+        request_started_at: str,
+        terminal_emitted_at: str | None,
         started_at: float | None = None,
     ) -> None:
         tail_started_at = time.monotonic()
-        logger.info(
-            "Session %s: slow tail work started (elapsed_ms=%s)",
-            session_id,
-            self._elapsed_ms(started_at),
+        tail_started_at_iso = _utc_now_iso()
+        self._log_prompt_lifecycle(
+            "hermes.acp.prompt.tail_work_started",
+            session_id=session_id,
+            turn_id=turn_id,
+            request_started_at=request_started_at,
+            terminal_emitted_at=terminal_emitted_at,
+            tail_work_started_at=tail_started_at_iso,
+            elapsed_ms=self._elapsed_ms(started_at),
         )
         try:
             await self._run_prompt_tail_work(session_id)
         except Exception:
+            self._log_prompt_lifecycle(
+                "hermes.acp.prompt.tail_work_failed",
+                session_id=session_id,
+                turn_id=turn_id,
+                level=logging.WARNING,
+                request_started_at=request_started_at,
+                terminal_emitted_at=terminal_emitted_at,
+                tail_work_started_at=tail_started_at_iso,
+                tail_work_finished_at=_utc_now_iso(),
+                elapsed_ms=self._elapsed_ms(started_at),
+                tail_work_duration_ms=self._elapsed_ms(tail_started_at),
+            )
             logger.warning(
-                "Session %s: slow tail work failed (elapsed_ms=%s, tail_elapsed_ms=%s)",
+                "Session %s: slow tail work failed",
                 session_id,
-                self._elapsed_ms(started_at),
-                self._elapsed_ms(tail_started_at),
                 exc_info=True,
             )
             return
-        logger.info(
-            "Session %s: slow tail work finished (elapsed_ms=%s, tail_elapsed_ms=%s)",
-            session_id,
-            self._elapsed_ms(started_at),
-            self._elapsed_ms(tail_started_at),
+        self._log_prompt_lifecycle(
+            "hermes.acp.prompt.tail_work_finished",
+            session_id=session_id,
+            turn_id=turn_id,
+            request_started_at=request_started_at,
+            terminal_emitted_at=terminal_emitted_at,
+            tail_work_started_at=tail_started_at_iso,
+            tail_work_finished_at=_utc_now_iso(),
+            elapsed_ms=self._elapsed_ms(started_at),
+            tail_work_duration_ms=self._elapsed_ms(tail_started_at),
         )
 
     # ---- Connection lifecycle -----------------------------------------------
@@ -450,6 +530,7 @@ class HermesACPAgent(acp.Agent):
             | EmbeddedResourceContentBlock
         ],
         session_id: str,
+        message_id: str | None = None,
         **kwargs: Any,
     ) -> PromptResponse:
         """Run Hermes on the user's prompt and stream events back to the editor."""
@@ -473,6 +554,15 @@ class HermesACPAgent(acp.Agent):
 
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
         prompt_started_at = time.monotonic()
+        request_started_at = _utc_now_iso()
+        turn_id = str(message_id or "").strip() or None
+        self._log_prompt_lifecycle(
+            "hermes.acp.prompt.request_started",
+            session_id=session_id,
+            turn_id=turn_id,
+            request_started_at=request_started_at,
+            prompt_chars=len(user_text),
+        )
 
         conn = self._conn
         loop = asyncio.get_running_loop()
@@ -510,17 +600,17 @@ class HermesACPAgent(acp.Agent):
             except Exception:
                 logger.debug("Could not set ACP approval callback", exc_info=True)
 
-        def _run_agent() -> dict:
+        def _run_agent() -> dict[str, Any]:
             try:
                 result = agent.run_conversation(
                     user_message=user_text,
                     conversation_history=state.history,
                     task_id=session_id,
                 )
-                return result
+                return {"result": result, "error": None}
             except Exception as e:
                 logger.exception("Agent error in session %s", session_id)
-                return {"final_response": f"Error: {e}", "messages": state.history}
+                return {"result": None, "error": str(e)}
             finally:
                 if approval_cb:
                     try:
@@ -530,19 +620,24 @@ class HermesACPAgent(acp.Agent):
                         logger.debug("Could not restore approval callback", exc_info=True)
 
         try:
-            result = await loop.run_in_executor(_executor, _run_agent)
+            run_outcome = await loop.run_in_executor(_executor, _run_agent)
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             return PromptResponse(stop_reason="end_turn")
+
+        result_payload = run_outcome.get("result")
+        result = result_payload if isinstance(result_payload, dict) else {}
+        agent_error = str(run_outcome.get("error") or "").strip() or None
 
         updated_history = result.get("messages")
         if updated_history:
             state.history = updated_history
 
-        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
+        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+        stop_reason = "cancelled" if cancelled else "end_turn"
 
         final_response = result.get("final_response", "")
-        if final_response and conn:
+        if final_response and conn and not agent_error:
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
             logger.info(
@@ -552,22 +647,34 @@ class HermesACPAgent(acp.Agent):
                 self._elapsed_ms(prompt_started_at),
             )
 
-        if stop_reason == "end_turn":
-            await self._emit_session_idle(
-                session_id,
-                conn=conn,
-                final_output=final_response,
-                started_at=prompt_started_at,
-            )
+        terminal = _PromptTerminalNotification(
+            method=(
+                "prompt/failed"
+                if agent_error
+                else "prompt/cancelled"
+                if cancelled
+                else "prompt/completed"
+            ),
+            status="failed" if agent_error else "cancelled" if cancelled else "completed",
+            final_output=final_response if not agent_error and not cancelled else "",
+            error_detail=agent_error,
+        )
+        terminal_emitted_at = await self._emit_prompt_terminal_notification(
+            session_id,
+            turn_id=turn_id,
+            conn=conn,
+            terminal=terminal,
+            request_started_at=request_started_at,
+            started_at=prompt_started_at,
+        )
 
         if updated_history:
-            self._track_tail_task(
-                asyncio.create_task(
-                    self._run_prompt_tail_work_logged(
-                        session_id,
-                        started_at=prompt_started_at,
-                    )
-                )
+            await self._run_prompt_tail_work_logged(
+                session_id,
+                turn_id=turn_id,
+                request_started_at=request_started_at,
+                terminal_emitted_at=terminal_emitted_at,
+                started_at=prompt_started_at,
             )
 
         usage = None
@@ -581,13 +688,43 @@ class HermesACPAgent(acp.Agent):
                 cached_read_tokens=usage_data.get("cached_tokens"),
             )
 
-        logger.info(
-            "Session %s: PromptResponse returned (stop_reason=%s, elapsed_ms=%s)",
+        await self._await_prompt_response_release(
             session_id,
-            stop_reason,
-            self._elapsed_ms(prompt_started_at),
+            turn_id=turn_id,
+            stop_reason=stop_reason,
+            request_started_at=request_started_at,
+            terminal_emitted_at=terminal_emitted_at,
         )
-        return PromptResponse(stop_reason=stop_reason, usage=usage)
+        request_returned_at = _utc_now_iso()
+        self._log_prompt_lifecycle(
+            "hermes.acp.prompt.request_returned",
+            session_id=session_id,
+            turn_id=turn_id,
+            request_started_at=request_started_at,
+            terminal_emitted_at=terminal_emitted_at,
+            request_returned_at=request_returned_at,
+            stop_reason=stop_reason,
+            elapsed_ms=self._elapsed_ms(prompt_started_at),
+            terminal_to_return_ms=(
+                max(
+                    int(
+                        (
+                            datetime.fromisoformat(request_returned_at)
+                            - datetime.fromisoformat(terminal_emitted_at)
+                        ).total_seconds()
+                        * 1000
+                    ),
+                    0,
+                )
+                if terminal_emitted_at
+                else None
+            ),
+        )
+        return PromptResponse(
+            stop_reason=stop_reason,
+            usage=usage,
+            user_message_id=turn_id,
+        )
 
     # ---- Slash commands (headless) -------------------------------------------
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Deque, Optional
@@ -138,6 +139,99 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._tail_tasks: set[asyncio.Task[None]] = set()
+
+    @staticmethod
+    def _elapsed_ms(started_at: float | None) -> int | None:
+        if started_at is None:
+            return None
+        return max(int((time.monotonic() - started_at) * 1000), 0)
+
+    def _track_tail_task(self, task: asyncio.Task[None]) -> None:
+        self._tail_tasks.add(task)
+
+        def _discard(done: asyncio.Task[None]) -> None:
+            self._tail_tasks.discard(done)
+            try:
+                done.result()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.exception("Unhandled ACP prompt tail task failure")
+
+        task.add_done_callback(_discard)
+
+    async def _emit_session_idle(
+        self,
+        session_id: str,
+        *,
+        conn: acp.Client | None,
+        final_output: str,
+        started_at: float | None = None,
+    ) -> None:
+        if conn is None:
+            return
+
+        raw_conn = getattr(conn, "_conn", None)
+        send_notification = getattr(raw_conn, "send_notification", None)
+        if not callable(send_notification):
+            logger.debug(
+                "Session %s: ACP transport does not expose raw notifications",
+                session_id,
+            )
+            return
+
+        payload: dict[str, Any] = {"sessionId": session_id}
+        if final_output:
+            payload["finalOutput"] = final_output
+        try:
+            await send_notification("session.idle", payload)
+        except Exception:
+            logger.warning(
+                "Session %s: terminal lifecycle signal failed (method=session.idle, elapsed_ms=%s)",
+                session_id,
+                self._elapsed_ms(started_at),
+                exc_info=True,
+            )
+            return
+        logger.info(
+            "Session %s: terminal lifecycle signal sent (method=session.idle, elapsed_ms=%s)",
+            session_id,
+            self._elapsed_ms(started_at),
+        )
+
+    async def _run_prompt_tail_work(self, session_id: str) -> None:
+        await asyncio.to_thread(self.session_manager.save_session, session_id)
+
+    async def _run_prompt_tail_work_logged(
+        self,
+        session_id: str,
+        *,
+        started_at: float | None = None,
+    ) -> None:
+        tail_started_at = time.monotonic()
+        logger.info(
+            "Session %s: slow tail work started (elapsed_ms=%s)",
+            session_id,
+            self._elapsed_ms(started_at),
+        )
+        try:
+            await self._run_prompt_tail_work(session_id)
+        except Exception:
+            logger.warning(
+                "Session %s: slow tail work failed (elapsed_ms=%s, tail_elapsed_ms=%s)",
+                session_id,
+                self._elapsed_ms(started_at),
+                self._elapsed_ms(tail_started_at),
+                exc_info=True,
+            )
+            return
+        logger.info(
+            "Session %s: slow tail work finished (elapsed_ms=%s, tail_elapsed_ms=%s)",
+            session_id,
+            self._elapsed_ms(started_at),
+            self._elapsed_ms(tail_started_at),
+        )
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -378,6 +472,7 @@ class HermesACPAgent(acp.Agent):
                 return PromptResponse(stop_reason="end_turn")
 
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
+        prompt_started_at = time.monotonic()
 
         conn = self._conn
         loop = asyncio.get_running_loop()
@@ -440,15 +535,40 @@ class HermesACPAgent(acp.Agent):
             logger.exception("Executor error for session %s", session_id)
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
-            state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
-            self.session_manager.save_session(session_id)
+        updated_history = result.get("messages")
+        if updated_history:
+            state.history = updated_history
+
+        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
 
         final_response = result.get("final_response", "")
         if final_response and conn:
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
+            logger.info(
+                "Session %s: first final assistant text sent (chars=%d, elapsed_ms=%s)",
+                session_id,
+                len(final_response),
+                self._elapsed_ms(prompt_started_at),
+            )
+
+        if stop_reason == "end_turn":
+            await self._emit_session_idle(
+                session_id,
+                conn=conn,
+                final_output=final_response,
+                started_at=prompt_started_at,
+            )
+
+        if updated_history:
+            self._track_tail_task(
+                asyncio.create_task(
+                    self._run_prompt_tail_work_logged(
+                        session_id,
+                        started_at=prompt_started_at,
+                    )
+                )
+            )
 
         usage = None
         usage_data = result.get("usage")
@@ -461,7 +581,12 @@ class HermesACPAgent(acp.Agent):
                 cached_read_tokens=usage_data.get("cached_tokens"),
             )
 
-        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
+        logger.info(
+            "Session %s: PromptResponse returned (stop_reason=%s, elapsed_ms=%s)",
+            session_id,
+            stop_reason,
+            self._elapsed_ms(prompt_started_at),
+        )
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -431,6 +432,145 @@ class TestPrompt:
         resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
 
         assert resp.stop_reason == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_prompt_emits_session_idle_before_slow_tail_work_finishes(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "done"},
+            ],
+        })
+
+        events: list[str] = []
+        raw_conn = SimpleNamespace()
+
+        async def _send_notification(method, params):
+            assert method == "session.idle"
+            assert params["sessionId"] == new_resp.session_id
+            assert params["finalOutput"] == "done"
+            events.append("session.idle")
+
+        raw_conn.send_notification = AsyncMock(side_effect=_send_notification)
+
+        async def _session_update(session_id, update):
+            assert session_id == new_resp.session_id
+            assert update.session_update == "agent_message_chunk"
+            events.append("agent_message_chunk")
+
+        agent._conn = SimpleNamespace(
+            session_update=AsyncMock(side_effect=_session_update),
+            request_permission=AsyncMock(),
+            _conn=raw_conn,
+        )
+
+        tail_started = asyncio.Event()
+        tail_release = asyncio.Event()
+        tail_finished = asyncio.Event()
+
+        async def _slow_tail_work(session_id):
+            assert session_id == new_resp.session_id
+            events.append("tail_started")
+            tail_started.set()
+            await tail_release.wait()
+            events.append("tail_finished")
+            tail_finished.set()
+
+        agent._run_prompt_tail_work = _slow_tail_work  # type: ignore[method-assign]
+
+        started_at = time.monotonic()
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+        returned_after = time.monotonic() - started_at
+
+        assert resp.stop_reason == "end_turn"
+        assert returned_after < 0.5
+        await asyncio.wait_for(tail_started.wait(), timeout=0.2)
+        assert not tail_finished.is_set()
+        assert events[:3] == ["agent_message_chunk", "session.idle", "tail_started"]
+
+        tail_release.set()
+        await asyncio.wait_for(tail_finished.wait(), timeout=0.2)
+
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_does_not_emit_session_idle(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def _mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": "interrupted",
+                "messages": [{"role": "user", "content": "stop"}],
+            }
+
+        state.agent.run_conversation = _mock_run
+
+        raw_conn = SimpleNamespace(send_notification=AsyncMock())
+        agent._conn = SimpleNamespace(
+            session_update=AsyncMock(),
+            request_permission=AsyncMock(),
+            _conn=raw_conn,
+        )
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="stop")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "cancelled"
+        raw_conn.send_notification.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompt_uses_captured_connection_and_ignores_idle_notification_failure(
+        self, agent
+    ):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "done"},
+            ],
+        })
+
+        first_raw_conn = SimpleNamespace()
+        second_raw_conn = SimpleNamespace(send_notification=AsyncMock())
+
+        async def _session_update(session_id, update):
+            assert session_id == new_resp.session_id
+            assert update.session_update == "agent_message_chunk"
+            agent._conn = SimpleNamespace(
+                session_update=AsyncMock(),
+                request_permission=AsyncMock(),
+                _conn=second_raw_conn,
+            )
+
+        first_raw_conn.send_notification = AsyncMock(
+            side_effect=RuntimeError("idle notification boom")
+        )
+        agent._conn = SimpleNamespace(
+            session_update=AsyncMock(side_effect=_session_update),
+            request_permission=AsyncMock(),
+            _conn=first_raw_conn,
+        )
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "end_turn"
+        first_raw_conn.send_notification.assert_awaited_once()
+        second_raw_conn.send_notification.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,8 +1,8 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import json
 import os
-import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -30,6 +30,18 @@ from acp.schema import (
 from acp_adapter.server import HermesACPAgent, HERMES_VERSION
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
+
+
+def _structured_log_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for record in caplog.records:
+        try:
+            payload = json.loads(record.getMessage())
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and "event" in payload:
+            events.append(payload)
+    return events
 
 
 @pytest.fixture()
@@ -434,7 +446,9 @@ class TestPrompt:
         assert resp.stop_reason == "cancelled"
 
     @pytest.mark.asyncio
-    async def test_prompt_emits_session_idle_before_slow_tail_work_finishes(self, agent):
+    async def test_prompt_emits_prompt_completed_before_slow_tail_work_finishes(
+        self, agent
+    ):
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
 
@@ -450,10 +464,12 @@ class TestPrompt:
         raw_conn = SimpleNamespace()
 
         async def _send_notification(method, params):
-            assert method == "session.idle"
+            assert method == "prompt/completed"
             assert params["sessionId"] == new_resp.session_id
+            assert params["turnId"] == "turn-123"
+            assert params["status"] == "completed"
             assert params["finalOutput"] == "done"
-            events.append("session.idle")
+            events.append("prompt/completed")
 
         raw_conn.send_notification = AsyncMock(side_effect=_send_notification)
 
@@ -482,24 +498,27 @@ class TestPrompt:
 
         agent._run_prompt_tail_work = _slow_tail_work  # type: ignore[method-assign]
 
-        started_at = time.monotonic()
-        resp = await agent.prompt(
-            prompt=[TextContentBlock(type="text", text="hello")],
-            session_id=new_resp.session_id,
+        prompt_task = asyncio.create_task(
+            agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hello")],
+                session_id=new_resp.session_id,
+                message_id="turn-123",
+            )
         )
-        returned_after = time.monotonic() - started_at
-
-        assert resp.stop_reason == "end_turn"
-        assert returned_after < 0.5
         await asyncio.wait_for(tail_started.wait(), timeout=0.2)
         assert not tail_finished.is_set()
-        assert events[:3] == ["agent_message_chunk", "session.idle", "tail_started"]
+        assert prompt_task.done() is False
+        assert events[:3] == ["agent_message_chunk", "prompt/completed", "tail_started"]
 
         tail_release.set()
         await asyncio.wait_for(tail_finished.wait(), timeout=0.2)
+        resp = await asyncio.wait_for(prompt_task, timeout=0.2)
+
+        assert resp.stop_reason == "end_turn"
+        assert resp.user_message_id == "turn-123"
 
     @pytest.mark.asyncio
-    async def test_prompt_cancelled_does_not_emit_session_idle(self, agent):
+    async def test_prompt_cancelled_emits_prompt_cancelled(self, agent):
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
 
@@ -522,13 +541,53 @@ class TestPrompt:
         resp = await agent.prompt(
             prompt=[TextContentBlock(type="text", text="stop")],
             session_id=new_resp.session_id,
+            message_id="turn-cancelled",
         )
 
         assert resp.stop_reason == "cancelled"
-        raw_conn.send_notification.assert_not_awaited()
+        raw_conn.send_notification.assert_awaited_once_with(
+            "prompt/cancelled",
+            {
+                "sessionId": new_resp.session_id,
+                "turnId": "turn-cancelled",
+                "status": "cancelled",
+            },
+        )
 
     @pytest.mark.asyncio
-    async def test_prompt_uses_captured_connection_and_ignores_idle_notification_failure(
+    async def test_prompt_failure_emits_prompt_failed(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(side_effect=RuntimeError("boom"))
+
+        raw_conn = SimpleNamespace(send_notification=AsyncMock())
+        agent._conn = SimpleNamespace(
+            session_update=AsyncMock(),
+            request_permission=AsyncMock(),
+            _conn=raw_conn,
+        )
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="explode")],
+            session_id=new_resp.session_id,
+            message_id="turn-failed",
+        )
+
+        assert resp.stop_reason == "end_turn"
+        assert resp.user_message_id == "turn-failed"
+        raw_conn.send_notification.assert_awaited_once_with(
+            "prompt/failed",
+            {
+                "sessionId": new_resp.session_id,
+                "turnId": "turn-failed",
+                "status": "failed",
+                "message": "boom",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_prompt_uses_captured_connection_and_ignores_terminal_notification_failure(
         self, agent
     ):
         new_resp = await agent.new_session(cwd=".")
@@ -566,11 +625,103 @@ class TestPrompt:
         resp = await agent.prompt(
             prompt=[TextContentBlock(type="text", text="hello")],
             session_id=new_resp.session_id,
+            message_id="turn-456",
         )
 
         assert resp.stop_reason == "end_turn"
         first_raw_conn.send_notification.assert_awaited_once()
         second_raw_conn.send_notification.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompt_emits_terminal_before_request_return_gate_releases(
+        self,
+        agent,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level("INFO")
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "done"},
+            ],
+        })
+
+        terminal_emitted = asyncio.Event()
+        release_return = asyncio.Event()
+        raw_conn = SimpleNamespace()
+
+        async def _send_notification(method, params):
+            assert method == "prompt/completed"
+            assert params["turnId"] == "turn-delayed"
+            terminal_emitted.set()
+
+        raw_conn.send_notification = AsyncMock(side_effect=_send_notification)
+        agent._conn = SimpleNamespace(
+            session_update=AsyncMock(),
+            request_permission=AsyncMock(),
+            _conn=raw_conn,
+        )
+
+        async def _gate_prompt_return(*args, **kwargs):
+            await release_return.wait()
+
+        agent._await_prompt_response_release = _gate_prompt_return  # type: ignore[method-assign]
+
+        prompt_task = asyncio.create_task(
+            agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hello")],
+                session_id=new_resp.session_id,
+                message_id="turn-delayed",
+            )
+        )
+        await asyncio.wait_for(terminal_emitted.wait(), timeout=0.2)
+        assert prompt_task.done() is False
+
+        release_return.set()
+        resp = await asyncio.wait_for(prompt_task, timeout=0.2)
+
+        assert resp.stop_reason == "end_turn"
+        structured_events = _structured_log_events(caplog)
+        for _ in range(20):
+            if any(
+                event.get("event") == "hermes.acp.prompt.tail_work_finished"
+                for event in structured_events
+            ):
+                break
+            await asyncio.sleep(0.01)
+            structured_events = _structured_log_events(caplog)
+        request_started = next(
+            event
+            for event in structured_events
+            if event.get("event") == "hermes.acp.prompt.request_started"
+        )
+        terminal_event = next(
+            event
+            for event in structured_events
+            if event.get("event") == "hermes.acp.prompt.terminal_emitted"
+        )
+        request_returned = next(
+            event
+            for event in structured_events
+            if event.get("event") == "hermes.acp.prompt.request_returned"
+        )
+        tail_finished = next(
+            event
+            for event in structured_events
+            if event.get("event") == "hermes.acp.prompt.tail_work_finished"
+        )
+
+        assert request_started["turn_id"] == "turn-delayed"
+        assert isinstance(request_started.get("request_started_at"), str)
+        assert terminal_event["terminal_method"] == "prompt/completed"
+        assert isinstance(terminal_event.get("terminal_emitted_at"), str)
+        assert isinstance(request_returned.get("request_returned_at"), str)
+        assert int(request_returned.get("terminal_to_return_ms") or 0) >= 0
+        assert int(tail_finished.get("tail_work_duration_ms") or 0) >= 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend the Hermes-side `TICKET-160` terminal-contract work with the `TICKET-300` follow-on so official ACP prompt turns emit authoritative `prompt/completed|failed|cancelled` notifications keyed by the incoming `messageId`
- add structured `hermes.acp.prompt.*` lifecycle logs that distinguish request start, terminal emission, tail persistence timing, and request return
- fix the `TICKET-360` durability finding by awaiting session persistence before `PromptResponse` returns, while still emitting the terminal notification before persistence and before delayed return gates

## Tickets
- Implements the Hermes-side work for `TICKET-160`
- Implements the Hermes-side follow-on work for `TICKET-300`
- Includes the final-review fix from `TICKET-360`

## Review Findings Resolved
- prompt completion no longer relies on `session.idle`; Hermes now emits explicit `prompt/completed`, `prompt/failed`, and `prompt/cancelled` notifications with `turnId`, `status`, and terminal detail fields
- prompt lifecycle logging now records `request_started_at`, `terminal_emitted_at`, `request_returned_at`, and tail-work timing fields for rollout debugging
- updated session history is durably persisted before `PromptResponse` returns, eliminating the crash window that existed when persistence ran only in a detached tail task

## Verification
- `.venv/bin/python -m pytest tests/acp/test_server.py -q`
- `.venv/bin/python -m pytest tests/acp -q`

## Residual Risk
- This branch intentionally does not keep a backward-compatibility `session.idle` fallback for older ACP consumers. The coordinated CAR branch in `Git-on-my-level/codex-autorunner#1352` understands the new `prompt/*` contract, but a mixed-version rollout to older editors would need an explicit compatibility strategy.
