### PR TITLE
feat(delegation): add model override param to delegate_task()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7447,6 +7447,7 @@ class AIAgent:
             toolsets=function_args.get("toolsets"),
             tasks=function_args.get("tasks"),
             max_iterations=function_args.get("max_iterations"),
+            model=function_args.get("model"),
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -9,6 +9,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
    or:     python tests/test_delegate.py
 """
 
+import importlib
 import json
 import os
 import sys
@@ -1342,6 +1343,51 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_model_forwarded(self, mock_creds, mock_cfg):
+        """Dispatcher-level model overrides must reach child agent construction."""
+        mock_creds.return_value = {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            sys.modules.pop("run_agent", None)
+            with patch.dict(sys.modules, {
+                "openai": MagicMock(OpenAI=MagicMock()),
+                "fire": MagicMock(),
+            }):
+                run_agent = importlib.import_module("run_agent")
+
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                },
+            )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4-20250514")
 
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1063,6 +1063,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -1072,13 +1073,17 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, model, role)
+      - Batch:  provide tasks array [{goal, context, toolsets, model, role}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'model' parameter overrides the model used by subagents.
+    In batch mode, tasks[N].model takes precedence over the top-level
+    model parameter.
 
     Returns JSON with results array, one entry per task.
     """
@@ -1163,12 +1168,13 @@ def delegate_task(
     try:
         for i, t in enumerate(task_list):
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
+            effective_model = t.get("model") or model or creds["model"]
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=effective_model,
                 max_iterations=effective_max_iter, task_count=n_tasks, parent_agent=parent_agent,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
@@ -1569,6 +1575,15 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the model for subagent(s). When set, subagents use this model "
+                    "instead of inheriting from the parent agent or delegation.model config. "
+                    "Example: 'anthropic/claude-sonnet-4-20250514' or 'gpt-4.1'. "
+                    "In batch mode, can be overridden per-task via tasks[].model."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -1589,6 +1604,10 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Per-task ACP args override.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task model override. Takes precedence over the top-level model parameter.",
                         },
                         "role": {
                             "type": "string",
@@ -1663,6 +1682,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),


### PR DESCRIPTION
## Summary

Adds `model` parameter to `delegate_task()` enabling callers to override
the LLM model used by subagents. Previously, subagents could only inherit
the parent's model or use the one from `delegation.model` config.

### Changes

- New top-level `model` param on `delegate_task()` sig + schema
- New per-task `model` key in batch mode (`tasks[].model`)
- Precedence: per-task > top-level > delegation.config > parent inherit
- No changes to `_build_child_agent()` or credential resolution

### Test Plan

- [x] Python syntax check passes
- [x] Model parameter threads through all layers (sig → schema → build → registry)
- [ ] Import-based schema validation command was blocked here because the repo-local `venv/` is missing in this worktree, system `python3` is 3.9, and the available 3.11 interpreter lacks repo deps such as `PyYAML`
